### PR TITLE
Populate package.metadata for cargo binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ rust-version = "1.62"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }.{ target }.{ archive-format }"
+
 [dependencies]
 anyhow = "1.0.53"
 cargo-config2 = "0.1.4"


### PR DESCRIPTION
This adds some [additional metadata](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md) so that cargo-binstall can find the packaged binaries in the github releases