### PR TITLE
Add include flags to RCFLAGS

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -186,6 +186,14 @@ impl XWinOptions {
                     )
                 );
 
+                cmd.env(
+                    format!("RCFLAGS"), 
+                    format!(
+                        "-I{dir}/crt/include -I{dir}/sdk/include/ucrt -I{dir}/sdk/include/um -I{dir}/sdk/include/shared",
+                        dir = xwin_cache_dir.display()
+                    )
+                );
+
                 let target_arch = target
                     .split_once('-')
                     .map(|(x, _)| x)


### PR DESCRIPTION
This fixed a `'winres.h' file not found` error I was running into when depending on a crate that builds a CMAKE project (`openxr-sys`).