### PR TITLE
ci: Fix macos release for binstall

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -38,8 +38,8 @@ jobs:
         if: "startsWith(github.ref, 'refs/tags/')"
         run: |
           cd target/release
-          tar czvf cargo-xwin-${{ steps.tag.outputs.tag }}.apple-darwin.tar.gz cargo-xwin
-          shasum -a 256 cargo-xwin-${{ steps.tag.outputs.tag }}.apple-darwin.tar.gz > cargo-xwin-${{ steps.tag.outputs.tag }}.apple-darwin.tar.gz.sha256
+          tar czvf cargo-xwin-${{ steps.tag.outputs.tag }}.universal2-apple-darwin.tar.gz cargo-xwin
+          shasum -a 256 cargo-xwin-${{ steps.tag.outputs.tag }}.universal2-apple-darwin.tar.gz > cargo-xwin-${{ steps.tag.outputs.tag }}.universal2-apple-darwin.tar.gz.sha256
           cd -
       - name: Upload binary to GitHub Release
         uses: svenstaro/upload-release-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Currently, it fails to install the binary on macos and according to [the docs](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md) it expects either the achitecture + -apple-darwin, universal-apple-darwin, or universal2-apple-darwin