### PR TITLE
bump xwin version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.63.0
+      - uses: dtolnay/rust-toolchain@1.64.0
       - run: cargo check
 
   fmt:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: dtolnay/rust-toolchain@1.67.0
       - run: cargo check
 
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,13 @@ dependencies = [
  "dirs",
  "fs-err",
  "indicatif",
+ "native-tls",
  "paste",
  "path-slash",
+ "rustls",
+ "rustls-pemfile",
  "tracing-subscriber",
+ "ureq",
  "which",
  "xwin",
 ]
@@ -772,15 +776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.1.3+3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,7 +783,6 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1085,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
@@ -1833,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "xwin"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47cd98379545559ca535e0118818ad7eefbfd6ca2b989c5be526b5f01ee91bd"
+checksum = "c43e0202f5457b48558096cb7b36d0e473f267551a89c82ed72d73b01dfd4007"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1848,12 +1842,9 @@ dependencies = [
  "indicatif",
  "memchr",
  "msi",
- "native-tls",
  "parking_lot",
  "rayon",
  "regex",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "once_cell",
  "serde",
  "shell-escape",
- "toml",
+ "toml 0.7.3",
 ]
 
 [[package]]
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "cfb"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+checksum = "b390793e912300f1aa713429f7fd0c391024e6c18b988962558bc4f96a349b1f"
 dependencies = [
  "byteorder",
  "fnv",
@@ -363,6 +363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +515,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -647,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "msi"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7124fc3188eff23916d20d82bcbbb993914b22fba5603f9e7745e347a86cf67"
+checksum = "226b2404f03d2cf47375b9715c8adfae4e388bb2377cff908e8a40f31e421514"
 dependencies = [
  "byteorder",
  "cfb",
@@ -1062,6 +1084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1107,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1158,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -1340,14 +1380,26 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.8",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -1358,11 +1410,24 @@ version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.1",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.19",
 ]
 
 [[package]]
@@ -1550,6 +1615,16 @@ checksum = "c73a36bc44e3039f51fbee93e39f41225f6b17b380eb70cc2aab942df06b34dd"
 dependencies = [
  "itertools",
  "nom",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1748,10 +1823,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "xwin"
-version = "0.3.1"
+name = "winnow"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79db6a9fc6b665feccd1984e4e21ff588102652c317176fab0d6706b55d3e208"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "xwin"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b999dbacd16114917b3835e1a7fb43880c8089d2ad887f2d35094de165319e8c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1759,22 +1843,28 @@ dependencies = [
  "camino",
  "clap",
  "cli-table",
+ "crossbeam-channel",
  "flate2",
  "indicatif",
+ "memchr",
  "msi",
  "native-tls",
  "parking_lot",
  "rayon",
  "regex",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
+ "toml 0.8.8",
  "tracing",
  "tracing-subscriber",
  "twox-hash",
  "ureq",
  "versions",
+ "walkdir",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "xwin"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b999dbacd16114917b3835e1a7fb43880c8089d2ad887f2d35094de165319e8c"
+checksum = "d47cd98379545559ca535e0118818ad7eefbfd6ca2b989c5be526b5f01ee91bd"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 keywords = ["windows", "cargo", "msvc"]
 readme = "README.md"
 repository = "https://github.com/rust-cross/cargo-xwin"
-rust-version = "1.63"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -26,7 +26,7 @@ paste = "1.0.12"
 path-slash = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
 which = "4.2.4"
-xwin = { version = "0.4.0", default-features = false }
+xwin = { version = "0.4.1", default-features = false }
 
 [features]
 # By default we use rustls for TLS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,20 @@ clap = { version = "4.0.0", features = ["derive", "env", "wrap_help"] }
 dirs = "5.0.0"
 fs-err = "2.7.0"
 indicatif = "0.17.2"
+native-tls-crate = { package = "native-tls", version = "0.2.11", optional = true }
 paste = "1.0.12"
 path-slash = "0.2.0"
+rustls = { version = "0.21.8", optional = true }
+rustls-pemfile = { version = "1.0.4", optional = true }
 tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
+ureq = { version = "2.8.0", default-features = false, features = ["gzip"] }
 which = "4.2.4"
-xwin = { version = "0.4.1", default-features = false }
+xwin = { version = "0.5.0", default-features = false }
 
 [features]
 # By default we use rustls for TLS
 default = ["rustls-tls"]
-rustls-tls = ["xwin/rustls-tls"]
+rustls-tls = ["ureq/tls", "rustls", "rustls-pemfile"]
 # If this feature is enabled we instead use the native TLS implementation for the
 # target platform
-native-tls = ["xwin/native-tls"]
+native-tls = ["ureq/native-tls", "rustls-pemfile", "native-tls-crate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ paste = "1.0.12"
 path-slash = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
 which = "4.2.4"
-xwin = { version = "0.3.1", default-features = false }
+xwin = { version = "0.4.0", default-features = false }
 
 [features]
 # By default we use rustls for TLS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 keywords = ["windows", "cargo", "msvc"]
 readme = "README.md"
 repository = "https://github.com/rust-cross/cargo-xwin"
-rust-version = "1.64"
+rust-version = "1.67"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -291,7 +291,7 @@ impl XWinOptions {
             .xwin_variant
             .iter()
             .fold(0, |acc, var| acc | *var as u32);
-        let pruned = xwin::prune_pkg_list(&pkg_manifest, arches, variants, false)?;
+        let pruned = xwin::prune_pkg_list(&pkg_manifest, arches, variants, false, None, None)?;
         let op = xwin::Ops::Splat(xwin::SplatConfig {
             include_debug_libs: self.xwin_include_debug_libs,
             include_debug_symbols: false,
@@ -299,11 +299,12 @@ impl XWinOptions {
             preserve_ms_arch_notation: false,
             copy: false,
             output: cache_dir.clone().try_into()?,
+            map: None,
         });
         let pkgs = pkg_manifest.packages;
 
         let mp = MultiProgress::with_draw_target(draw_target.into());
-        let work_items: Vec<_> = pruned
+        let work_items: Vec<_> = pruned.payloads
         .into_iter()
         .map(|pay| {
             let prefix = match pay.kind {
@@ -354,7 +355,7 @@ impl XWinOptions {
         .collect();
 
         mp.set_move_cursor(true);
-        ctx.execute(pkgs, work_items, arches, variants, op)?;
+        ctx.execute(pkgs, work_items, "".to_string(), arches, variants, op)?;
 
         let downloaded_arches: Vec<_> = self
             .xwin_arch


### PR DESCRIPTION
Further to [this issue](https://github.com/PyO3/maturin/issues/1836), I've created a fix in `xwin` crate to support custom ca cert when downloading microsoft CRT files. The PR has been merged and a new release `0.4.0` is available

https://github.com/Jake-Shadle/xwin/pull/104
https://github.com/Jake-Shadle/xwin/releases 

Hence this PR wants to bump up the version of `xwin` so that other upstream projects like `maturin` can benefit from this extra feature also