### PR TITLE
Add subcommands to manage the xwin installation

### DIFF
--- a/src/bin/cargo-xwin.rs
+++ b/src/bin/cargo-xwin.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsString;
 use std::process::Command;
 
-use cargo_xwin::{Build, Check, Clippy, Run, Rustc, Test};
+use cargo_xwin::{Build, Check, Clippy, InitXWin, Run, Rustc, Test};
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
@@ -12,13 +12,23 @@ use clap::{Parser, Subcommand};
     styles = cargo_options::styles(),
 )]
 pub enum Cli {
+    /// Can also be used to run all the cargo commands
     #[command(subcommand, name = "xwin")]
     Opt(Opt),
     // flatten opt here so that `cargo-xwin build` also works
     #[command(flatten)]
     Cargo(Opt),
+    /// Manage the xwin installation
+    #[command(subcommand, name = "manage-xwin")]
+    ManageXWin(ManageXWin),
     #[command(external_subcommand)]
     External(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
+#[command(version, display_order = 2)]
+pub enum ManageXWin {
+    Init(InitXWin),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -49,6 +59,9 @@ fn main() -> anyhow::Result<()> {
             Opt::Test(test) => test.execute()?,
             Opt::Check(check) => check.execute()?,
             Opt::Clippy(clippy) => clippy.execute()?,
+        },
+        Cli::ManageXWin(opt) => match opt {
+            ManageXWin::Init(init) => init.execute()?,
         },
         Cli::External(args) => {
             let mut child = Command::new(env::var_os("CARGO").unwrap_or("cargo".into()))

--- a/src/init_xwin.rs
+++ b/src/init_xwin.rs
@@ -1,0 +1,37 @@
+use std::{path::PathBuf, process::Command};
+
+use anyhow::Result;
+use cargo_options::heading;
+use clap::Parser;
+
+use crate::common::XWinOptions;
+
+#[derive(Clone, Debug, Default, Parser)]
+#[command(
+    display_order = 1,
+    about = "Run init command",
+    after_help = "",
+)]
+pub struct InitXWin {
+    #[command(flatten)]
+    common: cargo_options::CommonOptions,
+
+    /// Path to Cargo.toml
+    #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    pub manifest_path: Option<PathBuf>,
+
+    #[command(flatten)]
+    xwin: XWinOptions,
+}
+
+impl InitXWin {
+    pub fn execute(&self) -> Result<()> {
+        let mut build = Command::new("");
+        self.xwin.apply_command_env(
+            self.manifest_path.as_deref(),
+            &self.common,
+            &mut build,
+        )?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 mod common;
+mod init_xwin;
 mod macros;
 mod run;
 mod test;
 
 pub use common::XWinOptions;
+pub use init_xwin::InitXWin;
 pub use macros::{build::Build, check::Check, clippy::Clippy, rustc::Rustc};
 pub use run::Run;
 pub use test::Test;


### PR DESCRIPTION
Hello everyone,

I wanted to have the possibility to `initialize` all of the xwin downloads without creating a rust project first.
We can also add other management commands here later. For example:

 - remove the cache directory
 - update the downloaded xwin files
 - test if newer sdks are available

How do you like that idea?

Have a nice day!

Best regards,
Nicolas