### PR TITLE
Add option to include debug symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ for example, `cargo xwin test --target x86_64-pc-windows-msvc`
 
 The Microsoft CRT and Windows SDK can be customized using the following environment variables or CLI options.
 
-| Environment Variable      | CLI option                  | Description                                                                                                        |
-| ------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `XWIN_ARCH`               | `--xwin-arch`               | The architectures to include, defaults to `x86_64,aarch64`, possible values: x86, x86_64, aarch, aarch64           |
-| `XWIN_VARIANT`            | `--xwin-variant`            | The variants to include, defaults to `desktop`, possible values: desktop, onecore, spectre                         |
-| `XWIN_VERSION`            | `--xwin-version`            | The version to retrieve, defaults to 16, can either be a major version of 15 or 16, or a `<major>.<minor>` version |
-| `XWIN_CACHE_DIR`          | `--xwin-cache-dir`          | xwin cache directory to put CRT and SDK files                                                                      |
-| `XWIN_INCLUDE_DEBUG_LIBS` | `--xwin-include-debug-libs` | Whether or not to include debug libs in installation (default false).                                              |
+| Environment Variable         | CLI option                     | Description                                                                                                        |
+| ---------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `XWIN_ARCH`                  | `--xwin-arch`                  | The architectures to include, defaults to `x86_64,aarch64`, possible values: x86, x86_64, aarch, aarch64           |
+| `XWIN_VARIANT`               | `--xwin-variant`               | The variants to include, defaults to `desktop`, possible values: desktop, onecore, spectre                         |
+| `XWIN_VERSION`               | `--xwin-version`               | The version to retrieve, defaults to 16, can either be a major version of 15 or 16, or a `<major>.<minor>` version |
+| `XWIN_CACHE_DIR`             | `--xwin-cache-dir`             | xwin cache directory to put CRT and SDK files                                                                      |
+| `XWIN_INCLUDE_DEBUG_LIBS`    | `--xwin-include-debug-libs`    | Whether or not to include debug libs in installation (default false).                                              |
+| `XWIN_INCLUDE_DEBUG_SYMBOLS` | `--xwin-include-debug-symbols` | Whether or not to include debug symbols (PDBs) in installation (default false).                                    |
 
 ### CMake Support
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -54,6 +54,10 @@ pub struct XWinOptions {
     /// Whether or not to include debug libs
     #[arg(long, env = "XWIN_INCLUDE_DEBUG_LIBS", hide = true)]
     pub xwin_include_debug_libs: bool,
+
+    /// Whether or not to include debug symbols (PDBs)
+    #[arg(long, env = "XWIN_INCLUDE_DEBUG_SYMBOLS", hide = true)]
+    pub xwin_include_debug_symbols: bool,
 }
 
 impl Default for XWinOptions {
@@ -64,6 +68,7 @@ impl Default for XWinOptions {
             xwin_variant: vec![xwin::Variant::Desktop],
             xwin_version: "16".to_string(),
             xwin_include_debug_libs: false,
+            xwin_include_debug_symbols: false,
         }
     }
 }
@@ -295,7 +300,7 @@ impl XWinOptions {
         let pruned = xwin::prune_pkg_list(&pkg_manifest, arches, variants, false, None, None)?;
         let op = xwin::Ops::Splat(xwin::SplatConfig {
             include_debug_libs: self.xwin_include_debug_libs,
-            include_debug_symbols: false,
+            include_debug_symbols: self.xwin_include_debug_symbols,
             enable_symlinks: !cfg!(target_os = "macos"),
             preserve_ms_arch_notation: false,
             use_winsysroot_style: false,


### PR DESCRIPTION
(Basically the same as #72.)

Motivation for this is that compiling [ripgrep](https://github.com/BurntSushi/ripgrep/) fails with linker errors without that flag:
`cargo xwin build --target x86_64-pc-windows-msvc`
```
error: linking with `lld-link` failed: exit status: 1
[...]
  = note: lld-link: error: Cannot use debug info for 'libcmt.lib(std_type_info_static.obj)' [LNK4099]
          >>> failed to load reference 'd:\a01\_work\5\s\binaries\amd64ret\lib\amd64\libcmt.amd64.pdb': No such file or directory
[...]
```

In contrast (with this PR):
`rm -r ~/.cache/cargo-xwin/`
`cargo xwin build --target x86_64-pc-windows-msvc --xwin-include-debug-symbols`
_build succeeds_

Admittedly I have no idea what exactly causes debug symbols to become necessary for compilation here. Some other projects I've tested compile successfully without debug symbols.