### PR TITLE
Add doc subcommand

### DIFF
--- a/src/bin/cargo-xwin.rs
+++ b/src/bin/cargo-xwin.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsString;
 use std::process::Command;
 
-use cargo_xwin::{Build, Check, Clippy, Run, Rustc, Test};
+use cargo_xwin::{Build, Check, Clippy, Doc, Run, Rustc, Test};
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
@@ -29,6 +29,7 @@ pub enum Opt {
     Build(Build),
     Check(Check),
     Clippy(Clippy),
+    Doc(Doc),
     #[command(name = "run", alias = "r")]
     Run(Run),
     #[command(name = "rustc")]
@@ -49,6 +50,7 @@ fn main() -> anyhow::Result<()> {
             Opt::Test(test) => test.execute()?,
             Opt::Check(check) => check.execute()?,
             Opt::Clippy(clippy) => clippy.execute()?,
+            Opt::Doc(doc) => doc.execute()?,
         },
         Cli::External(args) => {
             let mut child = Command::new(env::var_os("CARGO").unwrap_or("cargo".into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod options;
 mod run;
 mod test;
 
-pub use macros::{build::Build, check::Check, clippy::Clippy, rustc::Rustc};
+pub use macros::{build::Build, check::Check, clippy::Clippy, doc::Doc, rustc::Rustc};
 pub use options::XWinOptions;
 pub use run::Run;
 pub use test::Test;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -91,4 +91,5 @@ macro_rules! cargo_command {
 cargo_command!(Build);
 cargo_command!(Check);
 cargo_command!(Clippy);
+cargo_command!(Doc);
 cargo_command!(Rustc);


### PR DESCRIPTION
I need `windows.h` in my bindgen project and if I want to look at the generated binding docs I basically need the context. Thanks for this awesome project, works like charm!