### PR TITLE
Add /EHsc flag to support C++ exceptions

### DIFF
--- a/src/compiler/clang_cl.rs
+++ b/src/compiler/clang_cl.rs
@@ -85,7 +85,7 @@ impl<'a> ClangCl<'a> {
                 );
                 cmd.env(
                     format!("CXXFLAGS_{env_target}"),
-                    format!("{cl_flags} {user_set_cxx_flags}",),
+                    format!("{cl_flags} /EHsc {user_set_cxx_flags}",),
                 );
 
                 cmd.env(
@@ -376,7 +376,7 @@ set(_CMAKE_C_FLAGS_INITIAL "${{CMAKE_C_FLAGS}}" CACHE STRING "")
 set(CMAKE_C_FLAGS "${{_CMAKE_C_FLAGS_INITIAL}} ${{COMPILE_FLAGS}}" CACHE STRING "" FORCE)
 
 set(_CMAKE_CXX_FLAGS_INITIAL "${{CMAKE_CXX_FLAGS}}" CACHE STRING "")
-set(CMAKE_CXX_FLAGS "${{_CMAKE_CXX_FLAGS_INITIAL}} ${{COMPILE_FLAGS}}" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${{_CMAKE_CXX_FLAGS_INITIAL}} ${{COMPILE_FLAGS}} /EHsc" CACHE STRING "" FORCE)
 
 string(REPLACE ";" " " LINK_FLAGS "${{LINK_FLAGS}}")
 


### PR DESCRIPTION
Building a dependency with C++ exceptions currently fails on cargo-xwin with `clang-cl`. Adding the [/EHsc](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model) flag fixes this problem.

````
  cargo:warning=foo.cpp(2,5): error: cannot use 'throw' with exceptions disabled
  cargo:warning=    2 |     throw 0;
  cargo:warning=      |     ^
  cargo:warning=1 error generated.
````

Minimal reproducible example:
https://gist.github.com/PaulWagener/b6c02566494c01897d99e12285c0d00d