### PR TITLE
Add env subcommand

### DIFF
--- a/src/bin/cargo-xwin.rs
+++ b/src/bin/cargo-xwin.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsString;
 use std::process::Command;
 
-use cargo_xwin::{Build, Check, Clippy, Doc, Run, Rustc, Test};
+use cargo_xwin::{Build, Check, Clippy, Doc, Env, Run, Rustc, Test};
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
@@ -36,6 +36,8 @@ pub enum Opt {
     Rustc(Rustc),
     #[command(name = "test", alias = "t")]
     Test(Test),
+    #[command(name = "env")]
+    Env(Env),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -51,6 +53,7 @@ fn main() -> anyhow::Result<()> {
             Opt::Check(check) => check.execute()?,
             Opt::Clippy(clippy) => clippy.execute()?,
             Opt::Doc(doc) => doc.execute()?,
+            Opt::Env(env) => env.execute()?,
         },
         Cli::External(args) => {
             let mut child = Command::new(env::var_os("CARGO").unwrap_or("cargo".into()))

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,86 @@
+use std::env;
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::options::XWinOptions;
+
+/// Print environment variables required for cross-compilation
+#[derive(Clone, Debug, Default, Parser)]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help test` for more detailed information.\nRun `cargo test -- --help` for test binary options."
+)]
+pub struct Env {
+    #[command(flatten)]
+    pub xwin: XWinOptions,
+
+    #[command(flatten)]
+    pub cargo: cargo_options::CommonOptions,
+
+    #[arg(long, value_name = "PATH")]
+    pub manifest_path: Option<PathBuf>,
+}
+
+impl Env {
+    /// Create a new env from manifest path
+    #[allow(clippy::field_reassign_with_default)]
+    pub fn new(manifest_path: Option<PathBuf>) -> Self {
+        let mut build = Self::default();
+        build.manifest_path = manifest_path;
+        build
+    }
+
+    /// Print env
+    pub fn execute(&self) -> Result<()> {
+        let mut env = self.build_command()?;
+
+        for target in &self.target {
+            if target.contains("msvc") {
+                if env::var_os("WINEDEBUG").is_none() {
+                    env.env("WINEDEBUG", "-all");
+                }
+                let env_target = target.to_uppercase().replace('-', "_");
+                let runner_env = format!("CARGO_TARGET_{}_RUNNER", env_target);
+                if env::var_os(&runner_env).is_none() {
+                    env.env(runner_env, "wine");
+                }
+            }
+        }
+
+        for (key, value) in env.get_envs() {
+            println!(
+                "{}={}",
+                key.to_string_lossy(),
+                value.unwrap_or_default().to_string_lossy()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Generate cargo subcommand
+    pub fn build_command(&self) -> Result<Command> {
+        let mut build = Command::new("cargo");
+        self.xwin
+            .apply_command_env(self.manifest_path.as_deref(), &self.cargo, &mut build)?;
+        Ok(build)
+    }
+}
+
+impl Deref for Env {
+    type Target = cargo_options::CommonOptions;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cargo
+    }
+}
+
+impl DerefMut for Env {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cargo
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -53,7 +53,7 @@ impl Env {
 
         for (key, value) in env.get_envs() {
             println!(
-                "export {}=\"{}\"",
+                "export {}=\"{}\";",
                 key.to_string_lossy(),
                 value.unwrap_or_default().to_string_lossy()
             );

--- a/src/env.rs
+++ b/src/env.rs
@@ -55,11 +55,7 @@ impl Env {
             println!(
                 "export {}=\"{}\"",
                 key.to_string_lossy(),
-                value
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .escape_debug()
-                    .collect::<String>()
+                value.unwrap_or_default().to_string_lossy()
             );
         }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -53,7 +53,7 @@ impl Env {
 
         for (key, value) in env.get_envs() {
             println!(
-                "{}={}",
+                "{}=\"{}\"",
                 key.to_string_lossy(),
                 value.unwrap_or_default().to_string_lossy()
             );

--- a/src/env.rs
+++ b/src/env.rs
@@ -10,10 +10,7 @@ use crate::options::XWinOptions;
 
 /// Print environment variables required for cross-compilation
 #[derive(Clone, Debug, Default, Parser)]
-#[command(
-    display_order = 1,
-    after_help = "Run `cargo help test` for more detailed information.\nRun `cargo test -- --help` for test binary options."
-)]
+#[command(display_order = 1)]
 pub struct Env {
     #[command(flatten)]
     pub xwin: XWinOptions,
@@ -21,7 +18,7 @@ pub struct Env {
     #[command(flatten)]
     pub cargo: cargo_options::CommonOptions,
 
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help_heading = cargo_options::heading::MANIFEST_OPTIONS)]
     pub manifest_path: Option<PathBuf>,
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -53,9 +53,13 @@ impl Env {
 
         for (key, value) in env.get_envs() {
             println!(
-                "{}=\"{}\"",
+                "export {}=\"{}\"",
                 key.to_string_lossy(),
-                value.unwrap_or_default().to_string_lossy()
+                value
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .escape_debug()
+                    .collect::<String>()
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 mod compiler;
+mod env;
 mod macros;
 mod options;
 mod run;
 mod test;
 
+pub use env::Env;
 pub use macros::{build::Build, check::Check, clippy::Clippy, doc::Doc, rustc::Rustc};
 pub use options::XWinOptions;
 pub use run::Run;


### PR DESCRIPTION
Example usage:
```bash
export CARGO_BUILD_TARGET="x86_64-pc-windows-msvc"
eval $(cargo xwin env)
cargo nextest archive --archive-file=my_tests.tar.zst
```