### PR TITLE
Update default manifest version to 17 to align with xwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The Microsoft CRT and Windows SDK can be customized using the following environm
 | `XWIN_CROSS_COMPILER`        | `--cross-compiler`             | The cross compiler to use, defaults to `clang-cl`, possible values: `clang-cl`, `clang`                            |
 | `XWIN_ARCH`                  | `--xwin-arch`                  | The architectures to include, defaults to `x86_64,aarch64`, possible values: x86, x86_64, aarch, aarch64           |
 | `XWIN_VARIANT`               | `--xwin-variant`               | The variants to include, defaults to `desktop`, possible values: desktop, onecore, spectre                         |
-| `XWIN_VERSION`               | `--xwin-version`               | The version to retrieve, defaults to 16, can either be a major version of 15 or 16, or a `<major>.<minor>` version |
+| `XWIN_VERSION`               | `--xwin-version`               | The version to retrieve, defaults to 17, can either be a major version of 15, 16, or 17, or a `<major>.<minor>` version |
 | `XWIN_SDK_VERSION`           | `--xwin-sdk-version`           | The SDK version to retrieve, defaults to the latest version                                                        |
 | `XWIN_CRT_VERSION`           | `--xwin-crt-version`           | The CRT version to retrieve, defaults to the latest version                                                        |
 | `XWIN_INCLUDE_ATL`           | `--xwin-include-atl`           | Whether to include the Active Template Library (ATL) in the installation                                           |

--- a/src/options.rs
+++ b/src/options.rs
@@ -55,7 +55,7 @@ pub struct XWinOptions {
 
     /// The version to retrieve, can either be a major version of 15, 16 or 17, or
     /// a "<major>.<minor>" version.
-    #[arg(long, env = "XWIN_VERSION", default_value = "16", hide = true)]
+    #[arg(long, env = "XWIN_VERSION", default_value = "17", hide = true)]
     pub xwin_version: String,
 
     /// If specified, this is the version of the SDK that the user wishes to use
@@ -86,7 +86,7 @@ impl Default for XWinOptions {
             xwin_cache_dir: None,
             xwin_arch: vec![xwin::Arch::X86_64, xwin::Arch::Aarch64],
             xwin_variant: vec![xwin::Variant::Desktop],
-            xwin_version: "16".to_string(),
+            xwin_version: "17".to_string(),
             xwin_sdk_version: None,
             xwin_crt_version: None,
             xwin_include_atl: false,


### PR DESCRIPTION
I got confused by the difference in default versions between `cargo xwin` and `xwin` itself, see #176.

It seems this was done once already, in https://github.com/rust-cross/cargo-xwin/pull/89. Not sure if this was reverted by mistake?