### PR TITLE
Add `bench` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-options"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89e1d6d6f65fe04d5e21be9de19d31a074e3b7e43aa39ee5b85f4cee16c3188"
+checksum = "b916a16b2a4b0ce91d46e42c51b7fc42e754220a4cc8bbfd1947efaafea99af7"
 dependencies = [
  "anstyle",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }.{ targe
 [dependencies]
 anyhow = "1.0.53"
 cargo-config2 = "0.1.4"
-cargo-options = "0.7.6"
+cargo-options = "0.8.1"
 clap = { version = "4.3.0", features = [
     "derive",
     "env",

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,92 @@
+use std::env;
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::process::{self, Command};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::options::XWinOptions;
+
+/// Execute all benchmarks of a local package
+#[derive(Clone, Debug, Default, Parser)]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help bench` for more detailed information."
+)]
+pub struct Bench {
+    #[command(flatten)]
+    pub xwin: XWinOptions,
+
+    #[command(flatten)]
+    pub cargo: cargo_options::Bench,
+}
+
+impl Bench {
+    /// Create a new bench from manifest path
+    #[allow(clippy::field_reassign_with_default)]
+    pub fn new(manifest_path: Option<PathBuf>) -> Self {
+        let mut build = Self::default();
+        build.manifest_path = manifest_path;
+        build
+    }
+
+    /// Execute `cargo bench` command
+    pub fn execute(&self) -> Result<()> {
+        let mut run = self.build_command()?;
+
+        for target in &self.cargo.target {
+            if target.contains("msvc") {
+                if env::var_os("WINEDEBUG").is_none() {
+                    run.env("WINEDEBUG", "-all");
+                }
+                let env_target = target.to_uppercase().replace('-', "_");
+                let runner_env = format!("CARGO_TARGET_{}_RUNNER", env_target);
+                if env::var_os(&runner_env).is_none() {
+                    run.env(runner_env, "wine");
+                }
+            }
+        }
+
+        let mut child = run.spawn().context("Failed to run cargo run")?;
+        let status = child.wait().expect("Failed to wait on cargo run process");
+        if !status.success() {
+            process::exit(status.code().unwrap_or(1));
+        }
+        Ok(())
+    }
+
+    /// Generate cargo subcommand
+    pub fn build_command(&self) -> Result<Command> {
+        let mut build = self.cargo.command();
+        self.xwin.apply_command_env(
+            self.manifest_path.as_deref(),
+            &self.cargo.common,
+            &mut build,
+        )?;
+        Ok(build)
+    }
+}
+
+impl Deref for Bench {
+    type Target = cargo_options::Bench;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cargo
+    }
+}
+
+impl DerefMut for Bench {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cargo
+    }
+}
+
+impl From<cargo_options::Bench> for Bench {
+    fn from(cargo: cargo_options::Bench) -> Self {
+        Self {
+            cargo,
+            ..Default::default()
+        }
+    }
+}

--- a/src/bin/cargo-xwin.rs
+++ b/src/bin/cargo-xwin.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsString;
 use std::process::Command;
 
-use cargo_xwin::{Build, Cache, Check, Clippy, Doc, Env, Run, Rustc, Test};
+use cargo_xwin::{Bench, Build, Cache, Check, Clippy, Doc, Env, Run, Rustc, Test};
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
@@ -26,6 +26,8 @@ pub enum Cli {
 #[derive(Debug, Subcommand)]
 #[command(version, display_order = 1)]
 pub enum Opt {
+    #[command(name = "bench")]
+    Bench(Bench),
     #[command(name = "build", alias = "b")]
     Build(Build),
     Check(Check),
@@ -49,6 +51,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli {
         Cli::Opt(opt) | Cli::Cargo(opt) => match opt {
+            Opt::Bench(bench) => bench.execute()?,
             Opt::Build(build) => build.execute()?,
             Opt::Run(run) => run.execute()?,
             Opt::Rustc(rustc) => rustc.execute()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod cache;
 mod compiler;
 mod env;
@@ -6,6 +7,7 @@ mod options;
 mod run;
 mod test;
 
+pub use bench::Bench;
 pub use cache::Cache;
 pub use env::Env;
 pub use macros::{build::Build, check::Check, clippy::Clippy, doc::Doc, rustc::Rustc};


### PR DESCRIPTION
Copied `test.rs` into `bench.rs` with minimal changes. I didn't want to touch `macros.rs` because it didn't set `WINEDEBUG` and `RUNNER` env vars

Tested locally on a criterion benchmark with the patch
```toml
[patch.crates-io]
cargo-options = { git = "https://github.com/anyduck/cargo-options", branch = "feat/bench" }
```
This depends on https://github.com/messense/cargo-options/pull/29