### PR TITLE
Support custom JSON targets by mimicking cargo target resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "paste",
  "path-slash",
  "serde",
+ "serde_json",
  "tar",
  "tracing-subscriber",
  "ureq",
@@ -1511,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ indicatif = "0.18.3"
 paste = "1.0.12"
 path-slash = "0.2.0"
 serde = { version = "1.0.216", features = ["derive"] }
+serde_json = "1.0.150"
 tar = "0.4.46"
 tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
 ureq = { version = "3.0.12", default-features = false, features = [

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -50,14 +50,18 @@ impl Clang {
         }
 
         for target in &targets {
-            if target.contains("msvc") {
+            let (cargo_target_name, llvm_target, is_custom_target) =
+                crate::compiler::common::resolve_target_info(target)?;
+
+            if llvm_target.contains("msvc") {
                 let msvc_sysroot_dir = self
                     .setup_msvc_sysroot(cache_dir.clone())
                     .context("Failed to setup MSVC sysroot")?;
+
                 // x86_64-pc-windows-msvc -> x86_64-windows-msvc
-                let target_no_vendor = target.replace("-pc-", "-");
-                let target_unknown_vendor = target.replace("-pc-", "-unknown-");
-                let env_target = target.to_lowercase().replace('-', "_");
+                let target_no_vendor = llvm_target.replace("-pc-", "-");
+                let target_unknown_vendor = llvm_target.replace("-pc-", "-unknown-");
+                let env_target = cargo_target_name.to_lowercase().replace('-', "_");
 
                 setup_llvm_tools(&env_path, &cache_dir).context("Failed to setup LLVM tools")?;
                 setup_target_compiler_and_linker_env(cmd, &env_target, "clang");
@@ -87,7 +91,19 @@ impl Clang {
                     format!("-I{dir}/include -I{dir}/include/c++/stl -I{dir}/include/__msvc_vcruntime_intrinsics", dir = sysroot_dir),
                 );
 
-                let mut rustflags = get_rustflags(&workdir, target)?.unwrap_or_default();
+                let mut rustflags =
+                    get_rustflags(&workdir, &cargo_target_name)?.unwrap_or_default();
+                if is_custom_target {
+                    rustflags.flags.push("-Zunstable-options".to_string());
+                    let mut paths = std::env::var_os("RUST_TARGET_PATH")
+                        .map(|v| std::env::split_paths(&v).collect::<Vec<_>>())
+                        .unwrap_or_default();
+
+                    if !paths.contains(&workdir) {
+                        paths.insert(0, workdir.clone());
+                        cmd.env("RUST_TARGET_PATH", std::env::join_paths(paths)?);
+                    }
+                }
                 rustflags.flags.extend([
                     "-C".to_string(),
                     "linker-flavor=lld-link".to_string(),
@@ -96,7 +112,7 @@ impl Clang {
                 ]);
 
                 // Check if static CRT is enabled
-                let is_static_crt = is_static_crt_enabled(&workdir, target)?;
+                let is_static_crt = is_static_crt_enabled(&workdir, &cargo_target_name)?;
                 if is_static_crt {
                     // When using static CRT, we need to link against the static version of libucrt
                     // instead of the import library. This resolves issues with symbols like
@@ -129,7 +145,7 @@ impl Clang {
 
                 // CMake support
                 let cmake_toolchain = self
-                    .setup_cmake_toolchain(target, &sysroot_dir, &cache_dir, is_static_crt)
+                    .setup_cmake_toolchain(&llvm_target, &sysroot_dir, &cache_dir, is_static_crt)
                     .with_context(|| format!("Failed to setup CMake toolchain for {}", target))?;
                 setup_cmake_env(cmd, target, cmake_toolchain);
             }

--- a/src/compiler/clang_cl.rs
+++ b/src/compiler/clang_cl.rs
@@ -16,7 +16,7 @@ use xwin::util::ProgressTarget;
 use crate::cache::prepare_xwin_cache_dir;
 use crate::compiler::common::{
     adjust_canonicalization, default_build_target_from_config, get_rustflags, http_agent,
-    is_static_crt_enabled, setup_cmake_env, setup_env_path, setup_llvm_tools,
+    is_static_crt_enabled, resolve_target_info, setup_cmake_env, setup_env_path, setup_llvm_tools,
     setup_target_compiler_and_linker_env,
 };
 use crate::options::XWinOptions;
@@ -58,10 +58,12 @@ impl<'a> ClangCl<'a> {
         }
 
         for target in &targets {
-            if target.contains("msvc") {
+            let (cargo_target_name, llvm_target, is_custom_target) = resolve_target_info(target)?;
+
+            if llvm_target.contains("msvc") {
                 self.setup_msvc_crt_with_retry(xwin_cache_dir.clone())
                     .context("Failed to setup MSVC CRT")?;
-                let env_target = target.to_lowercase().replace('-', "_");
+                let env_target = cargo_target_name.to_lowercase().replace('-', "_");
 
                 setup_clang_cl_symlink(&env_path, &cache_dir)
                     .context("Failed to setup clang-cl symlink")?;
@@ -72,7 +74,7 @@ impl<'a> ClangCl<'a> {
                 let user_set_c_flags = env::var("CFLAGS").unwrap_or_default();
                 let user_set_cxx_flags = env::var("CXXFLAGS").unwrap_or_default();
 
-                let target_arch = target
+                let target_arch = llvm_target
                     .split_once('-')
                     .map(|(x, _)| x)
                     .context("invalid target triple")?;
@@ -83,7 +85,7 @@ impl<'a> ClangCl<'a> {
 
                 let xwin_dir = adjust_canonicalization(xwin_cache_dir.to_slash_lossy().to_string());
                 let mut cl_flags = vec![
-                    format!("--target={target}"),
+                    format!("--target={llvm_target}"),
                     "-Wno-unused-command-line-argument".to_string(),
                     "-fuse-ld=lld-link".to_string(),
                     format!("/imsvc {dir}/crt/include", dir = xwin_dir),
@@ -140,13 +142,26 @@ impl<'a> ClangCl<'a> {
                 };
                 cmd.env("LIB", lib_value);
 
-                let mut rustflags = get_rustflags(&workdir, target)?.unwrap_or_default();
+                let mut rustflags =
+                    get_rustflags(&workdir, &cargo_target_name)?.unwrap_or_default();
+                if is_custom_target {
+                    rustflags.flags.push("-Zunstable-options".to_string());
+
+                    let mut paths = std::env::var_os("RUST_TARGET_PATH")
+                        .map(|v| std::env::split_paths(&v).collect::<Vec<_>>())
+                        .unwrap_or_default();
+
+                    if !paths.contains(&workdir) {
+                        paths.insert(0, workdir.clone());
+                        cmd.env("RUST_TARGET_PATH", std::env::join_paths(paths)?);
+                    }
+                }
                 rustflags
                     .flags
                     .extend(["-C".to_string(), "linker-flavor=lld-link".to_string()]);
 
                 // Check if static CRT is enabled
-                let is_static_crt = is_static_crt_enabled(&workdir, target)?;
+                let is_static_crt = is_static_crt_enabled(&workdir, &cargo_target_name)?;
                 if is_static_crt {
                     // When using static CRT, we need to link against the static version of libucrt
                     // instead of the import library. This resolves issues with symbols like
@@ -190,7 +205,7 @@ impl<'a> ClangCl<'a> {
 
                 // CMake support
                 let cmake_toolchain = self
-                    .setup_cmake_toolchain(target, &xwin_cache_dir, is_static_crt)
+                    .setup_cmake_toolchain(&llvm_target, &xwin_cache_dir, is_static_crt)
                     .with_context(|| format!("Failed to setup CMake toolchain for {}", target))?;
                 setup_cmake_env(cmd, target, cmake_toolchain);
             }

--- a/src/compiler/common.rs
+++ b/src/compiler/common.rs
@@ -1,10 +1,65 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use fs_err as fs;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use which::which_in;
+
+/// Mimics Cargo's target resolution to find and parse custom JSON targets.
+pub fn resolve_target_info(target: &str) -> Result<(String, String, bool)> {
+    let mut target_path = None;
+
+    // 1. Explicit file path
+    if target.ends_with(".json") {
+        target_path = Some(PathBuf::from(target));
+    } else {
+        // 2. Check current directory for {target}.json
+        let local_file = PathBuf::from(format!("{}.json", target));
+        if local_file.exists() {
+            target_path = Some(local_file);
+        } else {
+            // 3. Check RUST_TARGET_PATH environment variable
+            if let Ok(rust_target_path) = std::env::var("RUST_TARGET_PATH") {
+                for dir in std::env::split_paths(&rust_target_path) {
+                    let p = dir.join(format!("{}.json", target));
+                    if p.exists() {
+                        target_path = Some(p);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // 4. If we found a JSON file, parse it
+    if let Some(path) = target_path {
+        let stem = path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        let content = fs::read_to_string(&path).context(format!(
+            "Failed to read custom target file: {}",
+            path.display()
+        ))?;
+
+        let json: serde_json::Value =
+            serde_json::from_str(&content).context("Failed to parse custom target JSON")?;
+
+        let llvm_target = json
+            .get("llvm-target")
+            .and_then(|v| v.as_str())
+            .context("Custom target JSON missing 'llvm-target' field")?
+            .to_string();
+
+        return Ok((stem, llvm_target, true));
+    }
+
+    // 5. No JSON file found; assume it's a built-in target (e.g., "x86_64-pc-windows-msvc")
+    Ok((target.to_string(), target.to_string(), false))
+}
 
 /// Sets up the environment path by adding necessary directories to the existing `PATH`.
 ///


### PR DESCRIPTION
Currently, `cargo-xwin` does not correctly handle custom JSON targets (e.g., `cargo xwin build --target custom-win.json`).

# The Issue:
`cargo-xwin` relies on the raw `--target` string for all of its internal logic. Standard Cargo, however, supports target JSON files.

Because `cargo-xwin` conflated these two concepts, it caused several breakages:
- Config Resolution: It tries to look up `rustflags` in `.cargo/config.toml` under `[target.custom-win.json]` instead of `[target.custom-win]`.
- LLVM Parsing: It passes the literal string (e.g., `--target=custom-win.json`) to `clang` and `clang-cl`, resulting in triple parsing errors.
- Target Detection: It fails to trigger the MSVC setup if the custom filename doesn't explicitly contain the string "msvc".

# The Fix:
This PR introduces `resolve_target_info` in `compiler/common.rs` to replicate Cargo's native target resolution. It resolves the target by checking for explicit `.json` paths or searching the current directory and `RUST_TARGET_PATH`. It parses the JSON to extract the real `llvm_target` string, ensuring MSVC detection works and `clang-cl` gets a valid triple. It extracts the `cargo_target_name` (file stem) to accurately construct environment variables and retrieve Cargo configuration.